### PR TITLE
Update CTA block so if link is empty block still works.

### DIFF
--- a/modules/duo_blocks_cta/duo_blocks_cta.module
+++ b/modules/duo_blocks_cta/duo_blocks_cta.module
@@ -24,9 +24,10 @@ function duo_blocks_cta_preprocess_block(&$variables, $hook) {
     // let's go ahead and add that class, assuming that the front-end theme can
     // use it.
 
-  if (!empty($variables['content']['field_cta_links']['#items'])) {
-    $links = $variables['content']['field_cta_links']['#items'];
-    $links_count = $links->count();
+    // Make sure the link field has value, otherwise it breaks the page.
+    if (!empty($variables['content']['field_cta_links']['#items'])) {
+      $links = $variables['content']['field_cta_links']['#items'];
+      $links_count = $links->count();
 
       for ($i = 0; $i < $links_count; $i++) {
         $variables['content']['field_cta_links'][$i]['#options']['attributes']['class'][] = 'button';

--- a/modules/duo_blocks_cta/duo_blocks_cta.module
+++ b/modules/duo_blocks_cta/duo_blocks_cta.module
@@ -23,11 +23,14 @@ function duo_blocks_cta_preprocess_block(&$variables, $hook) {
     // Though we don't define any styles for the .button class in this module,
     // let's go ahead and add that class, assuming that the front-end theme can
     // use it.
+
+  if (!empty($variables['content']['field_cta_links']['#items'])) {
     $links = $variables['content']['field_cta_links']['#items'];
     $links_count = $links->count();
 
-    for ($i = 0; $i < $links_count; $i++) {
-      $variables['content']['field_cta_links'][$i]['#options']['attributes']['class'][] = 'button';
+      for ($i = 0; $i < $links_count; $i++) {
+        $variables['content']['field_cta_links'][$i]['#options']['attributes']['class'][] = 'button';
+      }
     }
   }
 }


### PR DESCRIPTION
The link on CTA blocks is not required, but if saving block and link is empty it throws undefined error.

Rather than make CTA link required, I added a check to see if the link field is empty.